### PR TITLE
Fix for build_kernel.sh

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -33,7 +33,7 @@ THREAD="-j$(grep -c ^processor /proc/cpuinfo)"
 ##### PATHS ####################################################
 
 AROOT="${PWD}"
-KERNEL_DIR="${AROOT}/kernel"
+KERNEL_DIR="${AROOT}"
 KERNEL_OUTPUT="${KERNEL_DIR}/out"
 KERNEL_FILE="Image.gz-dtb"
 KERNEL_FILE_DIR="${KERNEL_OUTPUT}/arch/${ARCH}/boot"


### PR DESCRIPTION
Kernel cannot be built if the KERNEL_DIR="${AROOT}/kernel"
There is no arch/arm64 in the /kernel directory.